### PR TITLE
Set working directory to `irpf.jar` location in wrapper script

### DIFF
--- a/br.gov.fazenda.receita.irpf2023.yaml
+++ b/br.gov.fazenda.receita.irpf2023.yaml
@@ -82,7 +82,7 @@ modules:
               echo "${0}: WARNING: Removing unsupported option '${BASH_REMATCH[0]}' from \$_JAVA_OPTIONS" >&2
               export _JAVA_OPTIONS="${_JAVA_OPTIONS//${unsupported_java_option}/}"
             fi
-            exec java -Djdk.gtk.version=2 -jar /app/extra/share/irpf.jar $@
+            cd /app/extra/share && exec java -Djdk.gtk.version=2 -jar irpf.jar $@
       - type: file
         path: br.gov.fazenda.receita.irpf2023.metainfo.xml
       - type: file


### PR DESCRIPTION
This fixed a bug in IRPF 2026 that would otherwise prevent us from visualizing or printing the tax receipt.

See: https://github.com/flathub/br.gov.fazenda.receita.irpf2026/pull/9

The bug doesn't affect this edition (at least currently), but this is a rather harmless change that I believe it's worth backporting.